### PR TITLE
E2e test alt typing

### DIFF
--- a/src/iceflow/ingest/atm1b.py
+++ b/src/iceflow/ingest/atm1b.py
@@ -12,9 +12,9 @@ import pandas as pd
 import pandera as pa
 from gps_timemachine.gps import leap_seconds
 from numpy.typing import DTypeLike
-from pandera.typing import DataFrame, Series
+from pandera.typing import Series
 
-from iceflow.ingest.models import DataFrame_co, commonDataColumns
+from iceflow.ingest.models import IceFlowData, commonDataColumns
 from iceflow.itrf import SUPPORTED_ITRFS
 
 """
@@ -384,8 +384,14 @@ class atm1bData(commonDataColumns):
     passive_footprint_synthesized_elevation: Series[pa.dtypes.Int32]
 
 
-@pa.check_types()
-def atm1b_data(filepath: Path) -> DataFrame[atm1bData]:
+class ATM1BData(IceFlowData):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Validate the data w/ pandera
+        atm1bData.validate(self)
+
+
+def atm1b_data(filepath: Path) -> ATM1BData:
     """
     Return the atm1b data given a filename.
 
@@ -425,6 +431,6 @@ def atm1b_data(filepath: Path) -> DataFrame[atm1bData]:
 
     data = data.set_index("utc_datetime")
 
-    data = DataFrame_co[atm1bData](data)
+    data = ATM1BData(data)
 
     return data

--- a/src/iceflow/ingest/atm1b.py
+++ b/src/iceflow/ingest/atm1b.py
@@ -14,7 +14,7 @@ from gps_timemachine.gps import leap_seconds
 from numpy.typing import DTypeLike
 from pandera.typing import Series
 
-from iceflow.ingest.models import IceFlowData, commonDataColumns
+from iceflow.ingest.models import IceFlowData, IceFlowDataSchema
 from iceflow.itrf import SUPPORTED_ITRFS
 
 """
@@ -368,7 +368,7 @@ def _ilatm1bv2_data(fn: Path, file_date: dt.date) -> pd.DataFrame:
     return df
 
 
-class atm1bData(commonDataColumns):
+class ATM1BDataSchema(IceFlowDataSchema):
     # Data fields unique to ATM1B data.
     rel_time: Series[pa.dtypes.Int32]
     xmt_sigstr: Series[pa.dtypes.Int32]
@@ -388,7 +388,10 @@ class ATM1BData(IceFlowData):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Validate the data w/ pandera
-        atm1bData.validate(self)
+        # TODO: Does this result in pandera validating the common columns twice?
+        # The `super` call above would trigger the `IceFlowData`'s __init__,
+        # which include a call to `validate` on the common data columns.
+        ATM1BDataSchema.validate(self)
 
 
 def atm1b_data(filepath: Path) -> ATM1BData:

--- a/src/iceflow/ingest/models.py
+++ b/src/iceflow/ingest/models.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
-from typing import Generic, TypeVar
+from typing import TypeVar
 
+import pandas as pd
 import pandera as pa
-from pandera.typing import DataFrame, Index, Series
+from pandera.typing import Index, Series
 
 from iceflow.itrf import SUPPORTED_ITRFS
 
 TDataFrame_co = TypeVar("TDataFrame_co", covariant=True)
-
-
-# Workaround for inheritance issue. See:
-# https://github.com/unionai-oss/pandera/issues/1170
-class DataFrame_co(DataFrame, Generic[TDataFrame_co]):  # type: ignore[type-arg]
-    pass
 
 
 class commonDataColumns(pa.DataFrameModel):
@@ -22,3 +17,10 @@ class commonDataColumns(pa.DataFrameModel):
     latitude: Series[pa.dtypes.Float] = pa.Field(coerce=True)
     longitude: Series[pa.dtypes.Float] = pa.Field(coerce=True)
     elevation: Series[pa.dtypes.Float] = pa.Field(coerce=True)
+
+
+class IceFlowData(pd.DataFrame):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Validate the data w/ pandera
+        commonDataColumns.validate(self)

--- a/src/iceflow/ingest/models.py
+++ b/src/iceflow/ingest/models.py
@@ -11,7 +11,7 @@ from iceflow.itrf import SUPPORTED_ITRFS
 TDataFrame_co = TypeVar("TDataFrame_co", covariant=True)
 
 
-class commonDataColumns(pa.DataFrameModel):
+class IceFlowDataSchema(pa.DataFrameModel):
     utc_datetime: Index[pa.dtypes.DateTime] = pa.Field(check_name=True)
     ITRF: Series[str] = pa.Field(isin=SUPPORTED_ITRFS)
     latitude: Series[pa.dtypes.Float] = pa.Field(coerce=True)
@@ -23,4 +23,4 @@ class IceFlowData(pd.DataFrame):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Validate the data w/ pandera
-        commonDataColumns.validate(self)
+        IceFlowDataSchema.validate(self)

--- a/src/iceflow/itrf/converter.py
+++ b/src/iceflow/itrf/converter.py
@@ -43,11 +43,7 @@ def transform_itrf(
     target_epoch: str | None = None,
 ) -> pd.DataFrame:
     """Pipeline string for proj to transform from the source to the target
-    ITRF frame and, optionally, epoch.
-
-    TODO:
-        * Update typing for function
-    """
+    ITRF frame and, optionally, epoch."""
     transformed_chunks = []
     for source_itrf, chunk in data.groupby(by="ITRF"):
         # If the source ITRF is the same as the target for this chunk, skip transformation.

--- a/src/iceflow/itrf/converter.py
+++ b/src/iceflow/itrf/converter.py
@@ -4,11 +4,9 @@ import datetime as dt
 import time
 
 import pandas as pd
-import pandera as pa
-from pandera.typing import DataFrame
 from pyproj import Transformer
 
-from iceflow.ingest.models import commonDataColumns
+from iceflow.ingest.models import IceFlowData
 from iceflow.itrf import ITRF
 
 
@@ -34,9 +32,8 @@ def _datetime_to_decimal_year(date):
     return date.year + fraction
 
 
-@pa.check_types()
 def transform_itrf(
-    data: DataFrame[commonDataColumns],
+    data: IceFlowData,
     target_itrf: ITRF,
     # These two must both be specified to apply the plate model
     # step. Nothing happens if only one is given. TODO: raise an error if

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -16,8 +16,7 @@ from typing import Literal
 import earthaccess
 import pandas as pd
 
-from iceflow.ingest.atm1b import atm1b_data, atm1bData
-from iceflow.ingest.models import DataFrame_co
+from iceflow.ingest.atm1b import ATM1BData, atm1b_data
 from iceflow.itrf.converter import transform_itrf
 
 ShortName = Literal["ILATM1B"]
@@ -83,7 +82,7 @@ def test_e2e(tmp_path):
 
     # This df contains data w/ two ITRFs: ITRF2005 and ITRF2008.
     complete_df = pd.concat(all_dfs)
-    complete_df = DataFrame_co[atm1bData](complete_df)
+    complete_df = ATM1BData(complete_df)
 
     transformed = transform_itrf(
         data=complete_df,


### PR DESCRIPTION
A follow-on from #8 , which provides an alternative approach to using `pandera` that is "more" (?) compatible with `mypy` for static type-checking. 

Rather than using `pandera` types directly, this PR subclasses `pandas.DataFrame` and calls `validate` using the appropriate `pandera` schema on init. This ensures that data instantiated from that class matches the schema.

The drawback is that we can't use `pandera`'s decorators that run validators on function inputs/outputs. My feeling is that this is an OK tradeoff because we still validate the data at instantiation, and we get the benefits of static typechecking. On the other hand, this approach could introduce subtle errors when something is typed as `IceFlowData`, but then a pandas operation mutates the dataframe (e.g., dropping a required column).

So...there are pros/cons for this approach and the one given in #8 . Another option would be to have `mypy` ignore pandera types. This could lead to mistakes in typing, but runtime validation would run. Are there other approaches worth considering? Could stop using `pandera` and stick with writing functions that take e.g., individual series as arguments instead of a dataframe that we expect to contain certain fields, but I was hoping to avoid that.