### PR TITLE
Validate ITRF structure instead of maintaining a support list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.2.0
 
 - Use `pydantic` to manage and validate dataset & dataset search parameters.
+- Fixup use of `pandera` to actually run validators.
 
 # v0.1.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ ignore = [
   "EM101",    # Exceptions should not use string literals
   "SIM108",   # Use ternary operator. Sometimes this is less readable.
   "T201",     # Remove 'print' statements. Sometimes these are handy.
+  "SIM105",   # Use contextlib.suppress instead of try-except-pass. The recommended approach is slower and less flexible.
 ]
 isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport

--- a/src/iceflow/api.py
+++ b/src/iceflow/api.py
@@ -10,7 +10,6 @@ from iceflow.data.models import (
     IceflowDataFrame,
 )
 from iceflow.data.read import read_data
-from iceflow.itrf import ITRF
 from iceflow.itrf.converter import transform_itrf
 
 
@@ -18,7 +17,7 @@ def fetch_iceflow_df(
     *,
     dataset_search_params: DatasetSearchParameters,
     output_dir: Path,
-    output_itrf: ITRF | None,
+    output_itrf: str | None,
 ) -> IceflowDataFrame:
     """Search for data matching parameters and return an IceflowDataframe.
 

--- a/src/iceflow/data/atm1b.py
+++ b/src/iceflow/data/atm1b.py
@@ -312,6 +312,7 @@ def extract_itrf(filepath: Path) -> str:
     itrf = itrf.upper()
 
     # Try to normalize based on known ITRF strings in the ATM1B data:
+    # TODO: extract this for reuse with other data products.
     try:
         itrf = {
             "ITRF05": "ITRF2005",

--- a/src/iceflow/data/atm1b.py
+++ b/src/iceflow/data/atm1b.py
@@ -14,7 +14,6 @@ from gps_timemachine.gps import leap_seconds
 from numpy.typing import DTypeLike
 
 from iceflow.data.models import ATM1BDataFrame
-from iceflow.itrf import SUPPORTED_ITRFS
 
 """
 The dtypes used to read any of the input ATM1B input files.
@@ -312,16 +311,14 @@ def extract_itrf(filepath: Path) -> str:
 
     itrf = itrf.upper()
 
-    if itrf not in SUPPORTED_ITRFS:
-        # Try to normalize:
-        try:
-            itrf = {
-                "ITRF05": "ITRF2005",
-                "ITRF08": "ITRF2008",
-            }[itrf]
-        except KeyError as e:
-            err = f"Unrecognized ATM1B ITRF {itrf}"
-            raise RuntimeError(err) from e
+    # Try to normalize based on known ITRF strings in the ATM1B data:
+    try:
+        itrf = {
+            "ITRF05": "ITRF2005",
+            "ITRF08": "ITRF2008",
+        }[itrf]
+    except KeyError:
+        pass
 
     return itrf
 
@@ -410,6 +407,4 @@ def atm1b_data(filepath: Path) -> ATM1BDataFrame:
 
     data = data.set_index("utc_datetime")
 
-    data = ATM1BDataFrame(data)
-
-    return data
+    return ATM1BDataFrame(data)

--- a/src/iceflow/data/models.py
+++ b/src/iceflow/data/models.py
@@ -2,28 +2,18 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import Sequence
-from typing import Generic, Literal, TypeVar
+from typing import Literal
 
 import pandera as pa
 import pydantic
 from pandera.typing import DataFrame, Index, Series
 
-from iceflow.itrf import SUPPORTED_ITRFS
-
-# Covariant type vars end with `_co` by convention. See:
-# https://peps.python.org/pep-0484/#covariance-and-contravariance
-TDataFrame_co = TypeVar("TDataFrame_co", covariant=True)
-
-
-# Workaround for inheritance issue. See:
-# https://github.com/unionai-oss/pandera/issues/1170
-class DataFrame_co(DataFrame, Generic[TDataFrame_co]):  # type: ignore[type-arg]
-    pass
+from iceflow.itrf import ITRF_REGEX
 
 
 class CommonDataColumnsSchema(pa.DataFrameModel):
     utc_datetime: Index[pa.dtypes.DateTime] = pa.Field(check_name=True)
-    ITRF: Series[str] = pa.Field(isin=SUPPORTED_ITRFS)
+    ITRF: Series[str] = pa.Field(str_matches=ITRF_REGEX.pattern)
     latitude: Series[pa.dtypes.Float] = pa.Field(coerce=True)
     longitude: Series[pa.dtypes.Float] = pa.Field(coerce=True)
     elevation: Series[pa.dtypes.Float] = pa.Field(coerce=True)
@@ -45,8 +35,8 @@ class ATM1BSchema(CommonDataColumnsSchema):
     passive_footprint_synthesized_elevation: Series[pa.dtypes.Int32]
 
 
-IceflowDataFrame = DataFrame_co[CommonDataColumnsSchema]
-ATM1BDataFrame = DataFrame_co[ATM1BSchema]
+IceflowDataFrame = DataFrame[CommonDataColumnsSchema]
+ATM1BDataFrame = DataFrame[ATM1BSchema]
 
 DatasetShortName = Literal["ILATM1B"]
 

--- a/src/iceflow/data/read.py
+++ b/src/iceflow/data/read.py
@@ -13,7 +13,7 @@ from iceflow.data.models import (
 
 
 @functools.singledispatch
-def read_data(dataset: Dataset, _filepath: Path) -> IceflowDataFrame:
+def read_data(dataset: Dataset, _filepath: Path) -> IceflowDataFrame | ATM1BDataFrame:
     msg = f"{dataset=} not recognized."
     raise RuntimeError(msg)
 

--- a/src/iceflow/itrf/__init__.py
+++ b/src/iceflow/itrf/__init__.py
@@ -1,23 +1,19 @@
 from __future__ import annotations
 
-from typing import Literal, get_args
+import re
 
-# ITRF strings recognized by proj, which is used in the ITRF transformation
-# code.
-# TODO: pyproj does recognize e.g., `ITRF1993` to be an alias of
-# `ITRF93`. Instead of being a hard-coded list, we could create a custom
-# validator for pandera that ensures the value is e.g., `ITRF\d{4}`, and then
-# the itrf transformation code could handle unrecognized ITRFs.
-ITRF = Literal[
-    "ITRF93",
-    "ITRF94",
-    "ITRF96",
-    "ITRF97",
-    "ITRF2000",
-    "ITRF2005",
-    "ITRF2008",
-    "ITRF2014",
-    "ITRF2020",
-]
+ITRF_REGEX = re.compile(r"^ITRF\d{2}(\d{2})?$")
 
-SUPPORTED_ITRFS: list[ITRF] = list(get_args(ITRF))
+
+def check_itrf(itrf_str: str) -> bool:
+    """Check if the given string is  a valid ITRF.
+
+    Based on a regex match. ITRF strings are conventionally "ITRF" followed by
+    the 2-digit or 4-digit year (e.g., "ITRF93" or "ITRF2008").
+
+    ITRFs prior to the 2000s conventionally used a 2-digit year (e.g.,
+    "ITRF88")."""
+
+    match = ITRF_REGEX.match(itrf_str)
+
+    return match is not None

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -16,11 +16,10 @@ import pandas as pd
 
 from iceflow.api import fetch_iceflow_df
 from iceflow.data.models import ATM1BDataset, DatasetSearchParameters, IceflowDataFrame
-from iceflow.itrf import ITRF
 
 
 def test_e2e(tmp_path):
-    target_itrf: ITRF = "ITRF2008"
+    target_itrf = "ITRF2008"
     common_bounding_box = (-103.125559, -75.180563, -102.677327, -74.798063)
     atm1b_v1_dataset = ATM1BDataset(version="1")
 

--- a/tests/unit/test_data_models.py
+++ b/tests/unit/test_data_models.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pandas as pd
+import pandera as pa
+import pytest
+
+from iceflow.data.models import IceflowDataFrame
+
+_mock_bad_df = pd.DataFrame(
+    {
+        "latitude": [70],
+        "longitude": [-50],
+        "elevation": [1],
+        "ITRF": ["should fail"],
+    },
+)
+
+
+def test_iceflowdataframe():
+    with pytest.raises(pa.errors.SchemaError):
+        IceflowDataFrame(_mock_bad_df)
+
+
+@pa.check_types
+def _pa_check_in(_df: IceflowDataFrame) -> None:
+    return None
+
+
+def test_pa_check_in():
+    with pytest.raises(pa.errors.SchemaError):
+        # The type ignore on the next line tells mypy to ignore that we're not
+        # casting to the expected input type. We want to test that
+        # `check_types` raises a runtime validation error
+        _pa_check_in(_mock_bad_df)  # type: ignore[arg-type]
+
+
+@pa.check_types
+def _pa_check_out(df: pd.DataFrame) -> IceflowDataFrame:
+    # The type ignore on the next line tells mypy to ignore that we're not
+    # casting to the expected return type. We want to test that
+    # `check_types` raises a runtime validation error
+    return df  # type: ignore[return-value]
+
+
+def test_pa_check_out():
+    with pytest.raises(pa.errors.SchemaError):
+        _pa_check_out(_mock_bad_df)

--- a/tests/unit/test_itrf.py
+++ b/tests/unit/test_itrf.py
@@ -4,9 +4,10 @@ from iceflow.itrf import check_itrf
 
 
 def test_check_itrf():
-    assert check_itrf("Not an ITRF string") is False
-    assert check_itrf("ITRF") is False
+    # These should return False
+    assert not check_itrf("Not an ITRF string")
+    assert not check_itrf("ITRF")
 
-    # These should pass.
-    assert check_itrf("ITRF2008") is True
-    assert check_itrf("ITRF88") is True
+    # These should return True
+    assert check_itrf("ITRF2008")
+    assert check_itrf("ITRF88")

--- a/tests/unit/test_itrf.py
+++ b/tests/unit/test_itrf.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from iceflow.itrf import check_itrf
+
+
+def test_check_itrf():
+    assert check_itrf("Not an ITRF string") is False
+    assert check_itrf("ITRF") is False
+
+    # These should pass.
+    assert check_itrf("ITRF2008") is True
+    assert check_itrf("ITRF88") is True

--- a/tests/unit/test_itrf_converter.py
+++ b/tests/unit/test_itrf_converter.py
@@ -8,25 +8,24 @@ from iceflow.itrf.converter import _datetime_to_decimal_year, transform_itrf
 
 
 def test_transform_itrf():
-    synth_df = IceflowDataFrame(
-        pd.DataFrame(
-            {
-                # Note: duplicate data here because otherwise a deprecation warning
-                # error about single-value series is raised from pandas' internals,
-                # and pytest complains.
-                "latitude": [70, 70],
-                "longitude": [-50, -50],
-                "elevation": [1, 1],
-                "ITRF": ["ITRF93", "ITRF93"],
-            },
-        )
+    synth_df = pd.DataFrame(
+        {
+            # Note: duplicate data here because otherwise a deprecation warning
+            # error about single-value series is raised from pandas' internals,
+            # and pytest complains.
+            "latitude": [70, 70],
+            "longitude": [-50, -50],
+            "elevation": [1, 1],
+            "ITRF": ["ITRF93", "ITRF93"],
+        },
     )
 
     constant_datetime = pd.to_datetime("1993-07-02 12:00:00")
     synth_df.index = pd.Index([constant_datetime] * 2, name="utc_datetime")
+    synth_iceflow_df = IceflowDataFrame(synth_df)
 
     result = transform_itrf(
-        data=synth_df,
+        data=synth_iceflow_df,
         target_itrf="ITRF2014",
     )
 


### PR DESCRIPTION
Also, make it so that pandera actually validates constraints! Using the covariant type approach was resulting in validations not running.

Resolves #7 