### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ You can set up a development environment with `conda` or your environment
 manager of choice:
 
 ```bash
-conda create -n iceflow-dev pip
+conda create -n iceflow-dev pip "python =3.12"
 conda activate iceflow-dev
 pip install --editable .[dev]
 ```


### PR DESCRIPTION
Need to spec. python 3.12 environment because python 3.13 breaks dependencies.

<!-- readthedocs-preview iceflow start -->
----
📚 Documentation preview 📚: https://iceflow--48.org.readthedocs.build/en/48/

<!-- readthedocs-preview iceflow end -->