### PR TITLE
update GH action for `attest-build-provenance`

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -46,7 +46,7 @@ jobs:
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@v1.4.3
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: "dist/*"
 


### PR DESCRIPTION
dependabot flagged this in #55. Pinning to `@v2` should let the minor and patch version update automatically

<!-- readthedocs-preview iceflow start -->
----
📚 Documentation preview 📚: https://iceflow--57.org.readthedocs.build/en/57/

<!-- readthedocs-preview iceflow end -->