### PR TITLE
Add `total_size_mb` property to `IceflowSearchResult` and log size when downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   lat/lon/elev fields.
 - Update data model for `IceflowDataFrame` to include `dataset`, which gives the
   dataset short name and version as a string (e.g., ILVIS v2 is "ILVISv2").
+- Add `total_size_mb` property to `IceflowSearchResult` and log size when
+  downloading.
 
 # v1.0.0
 

--- a/src/nsidc/iceflow/data/fetch.py
+++ b/src/nsidc/iceflow/data/fetch.py
@@ -61,6 +61,7 @@ def _download_iceflow_search_result(
 
     logger.info(
         f"Downloading {len(iceflow_search_result.granules)} granules"
+        f" (approx. {iceflow_search_result.total_size_mb} MB)"
         f" to {output_subdir}."
     )
 

--- a/src/nsidc/iceflow/data/models.py
+++ b/src/nsidc/iceflow/data/models.py
@@ -247,5 +247,10 @@ class IceflowSearchResult(pydantic.BaseModel):
     # this that type
     model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
+    @property
+    def total_size_mb(self):
+        granule_sizes_mb = [granule.size() for granule in self.granules]
+        return sum(granule_sizes_mb)
+
 
 IceflowSearchResults = list[IceflowSearchResult]


### PR DESCRIPTION
Resolves #34 

<!-- readthedocs-preview iceflow start -->
----
📚 Documentation preview 📚: https://iceflow--75.org.readthedocs.build/en/75/

<!-- readthedocs-preview iceflow end -->