### PR TITLE
Consistently use `nsidc-iceflow` instead of `iceflow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,15 @@
 - Update `transform_itrf` function to be more flexible. Both forward and reverse
   transformations between proj-supported ITRFs are now supported, which means
   that more ITRF-to-ITRF transformations are handled.
-- Update `icepyx` dependency to >=2.0.0 for the "Using iceflow with icepyx to
-  Generate an Elevation Timeseries" notebook.
+- Update `icepyx` dependency to >=2.0.0 for the "Using nsidc-iceflow with icepyx
+  to Generate an Elevation Timeseries" notebook.
 - Filter for cloud-hosted data, avoiding duplicate granule results from
   `fetch.find_iceflow_data`
 - Pass through search kwargs to `earthaccess` without any type validation. This
   allows earthaccess to do watever validation it needs to, and then it passes
   those on to CMR. This provides much greater flexibility over data search and
   makes the interface more consistent with `icepyx` and `earthaccess`.
-  https://github.com/nsidc/iceflow/issues/51.
+  https://github.com/nsidc/nsidc-iceflow/issues/51.
 - Remove restrictive `fetch_iceflow_df` function from public API. Users should
   utilize the search, download, and read functions described in
   `doc/getting-started.md` instead.
@@ -42,7 +42,7 @@
 - Add support for ILVIS2 v1 and v2.
 - Improve API, providing ability to search across datasets and save to
   intermediate parquet file.
-- Add jupyter notebook showing use of `iceflow` alongside `icepyx`
+- Add jupyter notebook showing use of `nsidc-iceflow` alongside `icepyx`
 
 # v0.2.0
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
   <img alt="NSIDC logo" src="https://nsidc.org/themes/custom/nsidc/logo.svg" width="150" />
 </p>
 
-# Iceflow Python Library
+# `nsidc-iceflow` Python Library
 
-`iceflow` is a Python library that provides the ability to search, download, and
-access laser altimetry data from (pre-)Operation IceBridge and ICESat/GLAS
-datasets. The library also supports International Terrestrial Reference Frame
-(ITRF) transformations to facilitate comparisons across datasets. `iceflow`
-supports the following datasets:
+`nsidc-iceflow` is a Python library that provides the ability to search,
+download, and access laser altimetry data from (pre-)Operation IceBridge and
+ICESat/GLAS datasets. The library also supports International Terrestrial
+Reference Frame (ITRF) transformations to facilitate comparisons across
+datasets. `nsidc-iceflow` supports the following datasets:
 
 | Dataset                                                  | Temporal Coverage             |
 | -------------------------------------------------------- | ----------------------------- |
@@ -26,12 +26,12 @@ submissions and pull requests in order to foster community contribution. We will
 strive to respond to contributions in a timely manner, but make no guarantees.
 
 If you discover any problems or bugs, please submit an
-[Issue](https://github.com/nsidc/iceflow/issues/new).
+[Issue](https://github.com/nsidc/nsidc-iceflow/issues/new).
 
 If you would like to contribute to this repository, you may fork the repository
 and submit a pull request. See our
 [contributing documentation](https://iceflow.readthedocs.io/en/latest/contributing.html)
-for more information about how to contribute to `iceflow`.
+for more information about how to contribute to `nsidc-iceflow`.
 
 See the [LICENSE](./LICENSE) for details on permissions and warranties. Please
 contact nsidc@nsidc.org for more information.
@@ -49,11 +49,11 @@ contact nsidc@nsidc.org for more information.
 pip install nsidc-iceflow
 ```
 
-### Using `iceflow`
+### Using `nsidc-iceflow`
 
 See
-[Getting started with iceflow](https://iceflow.readthedocs.io/en/latest/getting-started.html)
-for information and examples about how to use `iceflow`.
+[Getting started with `nsidc-iceflow`](https://iceflow.readthedocs.io/en/latest/getting-started.html)
+for information and examples about how to use `nsidc-iceflow`.
 
 ## Credit
 

--- a/docs/altimetry-data-overview.md
+++ b/docs/altimetry-data-overview.md
@@ -91,7 +91,7 @@ pulses are used to determine elevation data.
 ```{note}
 
 We recommend using the [_icepyx_](https://github.com/icesat2py/icepyx)
-library to access and interact with ICESat-2 data. Learn more about using `icepyx` with `iceflow` in the [Using iceflow with icepyx to Generate an Elevation Timeseries](notebooks/iceflow-with-icepyx) Jupyter notebook.
+library to access and interact with ICESat-2 data. Learn more about using `icepyx` with `nsidc-iceflow` in the [Using nsidc-iceflow with icepyx to Generate an Elevation Timeseries](notebooks/iceflow-with-icepyx) Jupyter notebook.
 
 ```
 
@@ -148,7 +148,7 @@ ILVIS V2 data:
 
 - `TLAT`/`TLON`/`ZT`, which represent the highest detected signal.
 
-By default, `iceflow` will use `GLAT`/`GLON`/`GZ` as the primary
+By default, `nsidc-iceflow` will use `GLAT`/`GLON`/`GZ` as the primary
 latitude/longitude/elevation fields in `IceflowDataFrame`s. Use the
 `ilvis2_coordinate_set` kwarg on `read_iceflow_datafile(s)` or
 `make_iceflow_parquet` to select an different primary set of
@@ -182,14 +182,14 @@ these missions presents several challenges:
   and longitude is the same. These changes in geolocation need to be reconciled
   to allow meaningful comparisons within the long-term data record.
 
-The `iceflow` Python library addresses these concerns by providing the ability
-to search, download, and access laser altimetry data from (pre-)Operation
-IceBridge and ICESat/GLAS datasets. The library also supports International
-Terrestrial Reference Frame (ITRF) transformations to facilitate comparisons
-across datasets.
+The `nsidc-iceflow` Python library addresses these concerns by providing the
+ability to search, download, and access laser altimetry data from
+(pre-)Operation IceBridge and ICESat/GLAS datasets. The library also supports
+International Terrestrial Reference Frame (ITRF) transformations to facilitate
+comparisons across datasets.
 
 Companion Jupyter notebooks give additional information and contain example code
-about `iceflow`.
+about `nsidc-iceflow`.
 
 [NSIDC Iceflow example](./notebooks/iceflow-example) provides an example of how
 to search for, download, and interact with `ILATM1B v1` data for a small area of
@@ -199,13 +199,13 @@ datasets. To learn more about ITRF transformations, see the
 [Applying Coordinate Transformations to Facilitate Data Comparison](./notebooks/corrections)
 notebook.
 
-[Using iceflow with icepyx to Generate an Elevation Timeseries](./notebooks/iceflow-with-icepyx)
+[Using nsidc-iceflow with icepyx to Generate an Elevation Timeseries](./notebooks/iceflow-with-icepyx)
 shows how to search for, download, and interact with a large amount of data
-across many datasets supported by `iceflow`. It also illustrates how to utilize
-[icepyx](https://icepyx.readthedocs.io/en/latest/) to find and access ICESat-2
-data. Finally, the notebook provides a simple time-series analysis for elevation
-change over an area of interest across `iceflow` supported datasets and
-ICESat-2.
+across many datasets supported by `nsidc-iceflow`. It also illustrates how to
+utilize [icepyx](https://icepyx.readthedocs.io/en/latest/) to find and access
+ICESat-2 data. Finally, the notebook provides a simple time-series analysis for
+elevation change over an area of interest across `nsidc-iceflow` supported
+datasets and ICESat-2.
 
 ## References
 
@@ -227,4 +227,4 @@ ICESat-2.
 With the knowledge gained from reading this page, users should be prepared for
 the [NSIDC Iceflow example](./notebooks/iceflow-example) notebook, which
 provides an example of how to search for, download, and interact with
-`ILATM1B v1` data for a small area of interest with the `iceflow` library.
+`ILATM1B v1` data for a small area of interest with the `nsidc-iceflow` library.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ html_theme_options: dict[str, Any] = {
     "footer_icons": [
         {
             "name": "GitHub",
-            "url": "https://github.com/NSIDC/iceflow",
+            "url": "https://github.com/NSIDC/nsidc-iceflow",
             "html": """
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
@@ -44,7 +44,7 @@ html_theme_options: dict[str, Any] = {
             "class": "",
         },
     ],
-    "source_repository": "https://github.com/NSIDC/iceflow",
+    "source_repository": "https://github.com/NSIDC/nsidc-iceflow",
     "source_branch": "main",
     "source_directory": "docs/",
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -44,7 +44,7 @@ Available tasks:
 
 ## Jupyter Notebooks
 
-There are Jupyter Notebooks showing `iceflow` functionality under
+There are Jupyter Notebooks showing `nsidc-iceflow` functionality under
 `docs/notebooks/`.
 
 To get started with developing existing or new notebooks, first install the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,26 +1,27 @@
-# Getting started with iceflow
+# Getting started with `nsidc-iceflow`
 
 ## Altimetry Overview
 
-Before working with `iceflow` directly, it may be helpful to understand the
-basics about pre-IceBridge, IceBridge, ICESat/GLAS and ICESat-2 datasets. Learn
-about these `iceflow` supported datasets in
+Before working with `nsidc-iceflow` directly, it may be helpful to understand
+the basics about pre-IceBridge, IceBridge, ICESat/GLAS and ICESat-2 datasets.
+Learn about these `nsidc-iceflow` supported datasets in
 [Altimetry Data at the NSIDC DAAC: Point Cloud Data Overview](./altimetry-data-overview)
 
 ## Jupyter Notebooks
 
-Executable Jupyter Notebooks provide a great starting point for using `iceflow`.
-See [Jupyter Notebooks](./notebooks/index.md) for more information.
+Executable Jupyter Notebooks provide a great starting point for using
+`nsidc-iceflow`. See [Jupyter Notebooks](./notebooks/index.md) for more
+information.
 
 ## API overview
 
-`iceflow` provides a simple API for finding, downloading, and accessing
+`nsidc-iceflow` provides a simple API for finding, downloading, and accessing
 iceflow-supported datasets.
 
 ### Finding data
 
-To find `iceflow`-supported data for an area of interest and timeframe, use
-[`find_iceflow_data`](nsidc.iceflow.find_iceflow_data):
+To find `nsidc-iceflow`-supported data for an area of interest and timeframe,
+use [`find_iceflow_data`](nsidc.iceflow.find_iceflow_data):
 
 ```
 import datetime as dt
@@ -54,7 +55,7 @@ search_results = find_iceflow_data(
 
 ```
 
-`iceflow` currently supports the following datasets:
+`nsidc-iceflow` currently supports the following datasets:
 
 | Dataset                                                  | Temporal Coverage             |
 | -------------------------------------------------------- | ----------------------------- |
@@ -139,7 +140,7 @@ crash if physical memory limits are exceeded.
 
 Users of ILVIS2 data should be aware that ILVIS2 data contains multiple sets of
 lat/lon/elev that may be of interest. By default, the `low_mode` set is used as
-the primary set of latitude/longitude/elevation used by `iceflow`.
+the primary set of latitude/longitude/elevation used by `nsidc-iceflow`.
 
 See [ILVIS2 data](./altimetry-data-overview.md#ilvis2-data) for more
 information.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# iceflow
+# `nsidc-iceflow`
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/notebooks/iceflow-example.ipynb
+++ b/docs/notebooks/iceflow-example.ipynb
@@ -5,7 +5,7 @@
    "id": "7174387c-05aa-4f8f-b3bd-902d4f635d9b",
    "metadata": {},
    "source": [
-    "# NSIDC Iceflow example\n",
+    "# `nsidc-iceflow` example\n",
     "\n",
     "This notebook shows an example of how to use the `nsidc-iceflow` Python library to do ITRF transformations with real data. We recommend starting with the [Applying Coordinate Transformations to Facilitate Data Comparison](./corrections) notebook to learn more about ITRF transformations and why they matter.\n",
     "\n",
@@ -15,7 +15,7 @@
     "\n",
     "Finding, downloading, and reading ILATM1B v1 data with `nsidc-iceflow` is straightforward. ILATM1B data can be very large, so for the purposes of this example we will focus on just a small area near Pine Island Glacier along with a short date range in order to fetch a manageable amount of data.\n",
     "\n",
-    "To learn about how to download and manage larger amounts of data across many datasets with `nsidc-iceflow`, see the [Using iceflow with icepyx to Generate an Elevation Timeseries](./iceflow-with-icepyx) notebook."
+    "To learn about how to download and manage larger amounts of data across many datasets with `nsidc-iceflow`, see the [Using nsidc-iceflow with icepyx to Generate an Elevation Timeseries](./iceflow-with-icepyx) notebook."
    ]
   },
   {

--- a/docs/notebooks/iceflow-with-icepyx.ipynb
+++ b/docs/notebooks/iceflow-with-icepyx.ipynb
@@ -5,11 +5,11 @@
    "id": "7174387c-05aa-4f8f-b3bd-902d4f635d9b",
    "metadata": {},
    "source": [
-    "# Using iceflow with icepyx to Generate an Elevation Timeseries\n",
+    "# Using `nsidc-iceflow` with icepyx to Generate an Elevation Timeseries\n",
     "\n",
     "This notebook shows how to produce a harmonized elevation timeseries across all iceflow-supported datasets along with ICESat-2 data using [icepyx](https://github.com/icesat2py/icepyx).\n",
     "\n",
-    "If this is your first time using `iceflow`, we recommend starting with the [NSIDC Iceflow example Jupyter Notebook](https://iceflow.readthedocs.io/en/latest/iceflow-example.html) first.\n",
+    "If this is your first time using `nsidc-iceflow`, we recommend starting with the [NSIDC Iceflow example Jupyter Notebook](https://iceflow.readthedocs.io/en/latest/iceflow-example.html) first.\n",
     "\n",
     "Similarly, if you are new to `icepyx`, we suggest reviewing the [icepyx documentation](https://icepyx.readthedocs.io/en/latest/) for more information about how to use `icepyx`."
    ]
@@ -779,7 +779,7 @@
     "\n",
     "We first need to define some constants, including our download path, ITRF, and filter parameters. These will be used throughout the rest of the notebook.\n",
     "\n",
-    "**Note that the data supported by `iceflow` and `icepyx` can be very large! This tutorial will download ~2GB worth of data to local disk.**"
+    "**Note that the data supported by `nsidc-iceflow` and `icepyx` can be very large! This tutorial will download ~2GB worth of data to local disk.**"
    ]
   },
   {
@@ -818,9 +818,9 @@
    "id": "420bf37c-c5cb-4339-bd26-ebb91ecb3973",
    "metadata": {},
    "source": [
-    "Next we will use the `find_iceflow_data` function from the `iceflow` API to find data matching our area of interest.\n",
+    "Next we will use the `find_iceflow_data` function from the `nsidc-iceflow` API to find data matching our area of interest.\n",
     "\n",
-    "By default, `find_iceflow_data` will include all `iceflow` supported datasets, unless one or more are specified as a filter with the `datasets` kwarg. There may be warnings raised about there not being search results for specific datasets supported by `iceflow`."
+    "By default, `find_iceflow_data` will include all `nsidc-iceflow` supported datasets, unless one or more are specified as a filter with the `datasets` kwarg. There may be warnings raised about there not being search results for specific datasets supported by `nsidc-iceflow`."
    ]
   },
   {
@@ -1126,7 +1126,7 @@
    "id": "fee85cd6-522f-4352-86ea-9530add68000",
    "metadata": {},
    "source": [
-    "Finally, we will create a parquet dataset using `make_iceflow_parquet`.Writing data to a parquet dataset allows `dask` (which we will use later!) to read the chunks of data it needs to do calculations (e.g., `mean`) without needing to read all of the data into memory at once. This is important because `iceflow` can find many millions of data points for even small areas of interest!\n",
+    "Finally, we will create a parquet dataset using `make_iceflow_parquet`.Writing data to a parquet dataset allows `dask` (which we will use later!) to read the chunks of data it needs to do calculations (e.g., `mean`) without needing to read all of the data into memory at once. This is important because `nsidc-iceflow` can find many millions of data points for even small areas of interest!\n",
     "\n",
     "This function transforms all data found in the `data_dir` to the provided `target_itrf`, further facilitating analysis across many datasets. \n",
     "\n",
@@ -2230,9 +2230,9 @@
    "id": "31d5cf8f-750e-4e9d-9cda-431d0a1a6a61",
    "metadata": {},
    "source": [
-    "`icepyx` reads ICESat-2 data as an xarray dataset. `xarray` is a powerful tool and the data is ready to use in this format, but to simplify things for this notebook and make the data more compatible with `iceflow`, the next step will convert the data into an `iceflow`-compatible [pandas DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/frame.html).\n",
+    "`icepyx` reads ICESat-2 data as an xarray dataset. `xarray` is a powerful tool and the data is ready to use in this format, but to simplify things for this notebook and make the data more compatible with `nsidc-iceflow`, the next step will convert the data into an `nsidc-iceflow`-compatible [pandas DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/frame.html).\n",
     "\n",
-    "The first step is to rename the variables to be consistent with how `iceflow` identifies the elevation and time fields:"
+    "The first step is to rename the variables to be consistent with how `nsidc-iceflow` identifies the elevation and time fields:"
    ]
   },
   {
@@ -2386,7 +2386,7 @@
     "df = df.dropna(subset=[\"latitude\", \"longitude\", \"elevation\"], how=\"any\")\n",
     "df = df.set_index(\"utc_datetime\")\n",
     "# Cast the df as an IceflowDataFrame.\n",
-    "# The `atl06_df` can now be used with e.g., `iceflow`'s ITRF conversion function\n",
+    "# The `atl06_df` can now be used with e.g., `nsidc-iceflow`'s ITRF conversion function\n",
     "# to perform plate motion model adjustments if desired.\n",
     "atl06_df = IceflowDataFrame(df)\n",
     "atl06_df.head()"
@@ -2428,7 +2428,7 @@
    "source": [
     "### Average elevation data over our area of interest at a weekly resolution\n",
     "\n",
-    "In this next step, we will resample the ATL06 and `iceflow` data to a weekly resolution, taking the mean of elevation over our area of interest. This will provide us with one data point per week where data is available, giving us a general idea of how the elevation of our area of interest changes over time. First we resample ATL06 data to a weekly mean:"
+    "In this next step, we will resample the ATL06 and `nsidc-iceflow` data to a weekly resolution, taking the mean of elevation over our area of interest. This will provide us with one data point per week where data is available, giving us a general idea of how the elevation of our area of interest changes over time. First we resample ATL06 data to a weekly mean:"
    ]
   },
   {
@@ -2704,7 +2704,7 @@
    "source": [
     "## Conclusions\n",
     "\n",
-    "In this notebook, we found and analyzed laser altimetry data from a variety of datasets using `iceflow` and `icepyx`. \n",
+    "In this notebook, we found and analyzed laser altimetry data from a variety of datasets using `nsidc-iceflow` and `icepyx`. \n",
     "\n",
     "In the timeseries plot above, we can see how the surface elevation of a small area near Sermeq Kujalleq (Jakobshavn Isbrae) changes over time.\n",
     "\n",
@@ -2712,7 +2712,7 @@
     "\n",
     "* Outlier detection and filtering\n",
     "* Cross-calibration of data between sensors/datasets\n",
-    "* Plate motion model coordinate propagation (see the [NSIDC Iceflow example Jupyter Notebook](https://iceflow.readthedocs.io/en/latest/iceflow-example.html) for an example of how to do this)\n",
+    "* Plate motion model coordinate propagation (see the [`nsidc-iceflow` example Jupyter Notebook](https://iceflow.readthedocs.io/en/latest/iceflow-example.html) for an example of how to do this)\n",
     "* Account for spatial variability within our region of interest"
    ]
   }

--- a/docs/notebooks/index.md
+++ b/docs/notebooks/index.md
@@ -11,13 +11,13 @@
 ```
 
 [Jupyter notebooks](https://docs.jupyter.org/en/latest/) provide executable
-examples of how to use `iceflow`.
+examples of how to use `nsidc-iceflow`.
 
 ## Prerequisites
 
-The `iceflow` notebooks are best approached with some familiarity with Python
-and its geoscience stack. If you feel like learning more about geoscience and
-Python, you can find great tutorials by CU Boulder's Earth Lab here:
+The `nsidc-iceflow` notebooks are best approached with some familiarity with
+Python and its geoscience stack. If you feel like learning more about geoscience
+and Python, you can find great tutorials by CU Boulder's Earth Lab here:
 [Data Exploration and Analysis Lessons](https://www.earthdatascience.org/tags/data-exploration-and-analysis/)
 or by the Data Carpentry project:
 [Introduction to Geospatial Concepts](https://datacarpentry.org/organization-geospatial/)
@@ -36,7 +36,7 @@ Some Python packages/libraries that users may consider investigating include:
   lazy Out-of-Core dataframes (similar to _pandas_), to visualize and explore
   big tabular data sets
 
-## Iceflow notebooks
+## `nsidc-iceflow` notebooks
 
 - [NSIDC Iceflow example](./iceflow-example) provides an example of how to
   search for, download, and interact with `ILATM1B v1` data for a small area of
@@ -46,16 +46,16 @@ Some Python packages/libraries that users may consider investigating include:
   [Applying Coordinate Transformations to Facilitate Data Comparison](./corrections)
   notebook.
 
-- [Using iceflow with icepyx to Generate an Elevation Timeseries](./iceflow-with-icepyx)
+- [Using nsidc-iceflow with icepyx to Generate an Elevation Timeseries](./iceflow-with-icepyx)
   shows how to search for, download, and interact with a large amount of data
-  across many datasets supported by `iceflow`. It also illustrates how to
+  across many datasets supported by `nsidc-iceflow`. It also illustrates how to
   utilize [icepyx](https://icepyx.readthedocs.io/en/latest/) to find and access
   ICESat-2 data. Finally, the notebook provides a simple time-series analysis
-  for elevation change over an area of interest across `iceflow` supported
+  for elevation change over an area of interest across `nsidc-iceflow` supported
   datasets and ICESat-2.
 
-### Downloading Iceflow notebooks
+### Downloading `nsidc-iceflow` notebooks
 
-Users may wish to try executing the Iceflow notebooks themselves. Iceflow
-notebooks can be downloaded
-[from GitHub](https://github.com/nsidc/iceflow/tree/main/docs/notebooks/).
+Users may wish to try executing the `nsidc-iceflow` notebooks themselves.
+Iceflow notebooks can be downloaded
+[from GitHub](https://github.com/nsidc/nsidc-iceflow/tree/main/docs/notebooks/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/NSIDC/iceflow"
-"Bug Tracker" = "https://github.com/NSIDC/iceflow/issues"
-Discussions = "https://github.com/NSIDC/iceflow/discussions"
-Changelog = "https://github.com/NSIDC/iceflow/releases"
+Homepage = "https://github.com/NSIDC/nsidc-iceflow"
+"Bug Tracker" = "https://github.com/NSIDC/nsidc-iceflow/issues"
+Discussions = "https://github.com/NSIDC/nsidc-iceflow/discussions"
+Changelog = "https://github.com/NSIDC/nsidc-iceflow/releases"
 
 [project.optional-dependencies]
 dev = [
@@ -196,7 +196,7 @@ commit = false
 tag = false
 
 [[tool.bumpversion.files]]
-filename = "src/nsidc/iceflow/__init__.py"
+filename = "src/nsidc/nsidc-iceflow/__init__.py"
 search   = '__version__ = "v{current_version}"'
 replace  = '__version__ = "v{new_version}"'
 

--- a/src/nsidc/iceflow/__init__.py
+++ b/src/nsidc/iceflow/__init__.py
@@ -3,7 +3,7 @@ Copyright (c) 2025 NSIDC. All rights reserved.
 
 iceflow: Harmonized access to (pre)OIB/IceSAT/IceSAT2 data
 
-Users interact with `iceflow` by:
+Users interact with `nsidc-iceflow` by:
 
 * Searching for data that match an area of interest/time (`find_iceflow_data`)
 * Downloading data (`download_iceflow_results`)

--- a/src/nsidc/iceflow/api.py
+++ b/src/nsidc/iceflow/api.py
@@ -1,4 +1,4 @@
-"""Module with functions defining the user-facing API for iceflow."""
+"""Module with functions defining the user-facing API for nsidc-iceflow."""
 
 from __future__ import annotations
 

--- a/src/nsidc/iceflow/data/atm1b.py
+++ b/src/nsidc/iceflow/data/atm1b.py
@@ -327,7 +327,7 @@ def _infer_qfit_itrf(filepath: Path) -> str:
     From which we extract an ITRF of `ITRF2005` from the `_itrf05_` bit.
 
     According to Michael Studinger (see
-    https://github.com/nsidc/iceflow/issues/35#issuecomment-2408619586), This
+    https://github.com/nsidc/nsidc-iceflow/issues/35#issuecomment-2408619586), This
     string represents the "GPS trajectory that was used to reference the lidar
     data and that has the ITRF epoch in its file name."
     """

--- a/src/nsidc/iceflow/data/glah06.py
+++ b/src/nsidc/iceflow/data/glah06.py
@@ -247,7 +247,7 @@ def glah06_data(filepath: Path) -> GLAH06DataFrame:
 
     # Add the ITRF
     df["ITRF"] = GLAH06_ITRF
-    # To be consistent with the other `iceflow` datasets, copy the primary
+    # To be consistent with the other `nsidc-iceflow` datasets, copy the primary
     # lat/lon/elev fields to the standard "latitude", "longitude", "elevation"
     # field names.
     df["latitude"] = df["d_lat"]

--- a/src/nsidc/iceflow/data/models.py
+++ b/src/nsidc/iceflow/data/models.py
@@ -131,7 +131,7 @@ class GLAH06Schema(CommonDataColumnsSchema):
     # group. There is also a "Data_1HZ" group, which contains similar variables,
     # but does not include the elevation data and appears to be a downsampled
     # version of the "Data_40HZ" group. See
-    # https://github.com/nsidc/iceflow/issues/43.
+    # https://github.com/nsidc/nsidc-iceflow/issues/43.
     i_rec_ndx: Series[int] = pa.Field(coerce=True)
     i_shot_count: Series[int] = pa.Field(coerce=True)
     d_lat: Series[float]

--- a/src/nsidc/iceflow/itrf/converter.py
+++ b/src/nsidc/iceflow/itrf/converter.py
@@ -69,7 +69,7 @@ def _itrf_transformation_step(source_itrf: str, target_itrf: str) -> str:
     """
     # The `+inv` reverses the transformation. So `+init=ITRF2014:ITRF2008`
     # performs a helmert transform from ITRF2008 to ITRF2014.  This is the most
-    # common case for `iceflow`, because we tend to be targeting pre-icesat2
+    # common case for `nsidc-iceflow`, because we tend to be targeting pre-icesat2
     # data for transformation to ITRF2014 (icesat2), so try this first.
     inv_itrf_transformation_step = f"+step +inv +init={target_itrf}:{source_itrf}"
     if _check_valid_proj_step(inv_itrf_transformation_step):


### PR DESCRIPTION
ReadTheDocs will continue to live at https://iceflow.readthedocs.io/en/latest/.

<!-- readthedocs-preview iceflow start -->
----
📚 Documentation preview 📚: https://iceflow--76.org.readthedocs.build/en/76/

<!-- readthedocs-preview iceflow end -->